### PR TITLE
Fix NSID regex.

### DIFF
--- a/content/specs/nsid.md
+++ b/content/specs/nsid.md
@@ -41,7 +41,7 @@ The comprehensive list of syntax rules is:
 A reference regex for NSID is:
 
 ```
-/^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.([a-zA-Z]{1,63}))$
+/^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.[a-zA-Z]([a-zA-Z]{0,61}[a-zA-Z])?)$/
 ```
 
 


### PR DESCRIPTION
Copied from

https://github.com/bluesky-social/atproto/blob/73f64009a22b3428a21a6d7807aee89d629fd0a4/packages/nsid/src/index.ts#L100

This now matches `cn.8.lex.stuff`, which the old regex didn't.